### PR TITLE
Fix Roboto fontface path

### DIFF
--- a/bundles/org.openhab.ui.basic/gulpfile.js
+++ b/bundles/org.openhab.ui.basic/gulpfile.js
@@ -16,8 +16,8 @@
 	
 	var paths = {
 	        FontLibs: [
-                './node_modules/roboto-fontface/fonts/Roboto-Medium.*',
-                './node_modules/roboto-fontface/fonts/Roboto-Regular.*',
+                './node_modules/roboto-fontface/fonts/roboto/Roboto-Medium.*',
+                './node_modules/roboto-fontface/fonts/roboto/Roboto-Regular.*',
                 './node_modules/material-design-icons/iconfont/MaterialIcons-Regular.*'
 	        ]
 	    };


### PR DESCRIPTION
At least in the latest version of roboto-fontface node module, Roboto Medium and Regular fonts are placed in `./node_modules/roboto-fontface/fonts/roboto/` directory not in `./node_modules/roboto-fontface/fonts/` so the paths are not found and Roboto-Medium.* and Roboto-Regular.* fonts are not copied into `./src/main/resources/web` directory. 
This is causing issue #1273.